### PR TITLE
Export TelemachyTourComponent for extensibility

### DIFF
--- a/src/component/telemachy.component.html
+++ b/src/component/telemachy.component.html
@@ -19,7 +19,7 @@
 		<div class="overlay" [ngStyle]="{top: 0, left:0, width: '100%', height: documentHeight}"></div>
 		<div class="popup">
 			<div class="content">
-				<div [innerHtml]="step.body" class="body"></div>
+				<div [innerHtml]="asHtmlTourStep(step).body" class="body"></div>
 				<div class="controls">
 					<a *ngIf="canGoBack()" (click)="previous()">&larr;</a>
 					<a *ngIf="!canFinish()" (click)="next()">&rarr;</a>
@@ -38,7 +38,7 @@
 
 		<div class="explanation" [ngStyle]="{left: step.left, top: step.bottom, width: (step.domElement.getBoundingClientRect().width - 2) + 'px'}">
 			<div class="content">
-				<div [innerHtml]="step.body"></div>
+				<div [innerHtml]="asElementTourStep(step).body"></div>
 				<div class="controls">
 					<a *ngIf="canGoBack()" (click)="previous()">&larr;</a>
 					<a *ngIf="!canFinish()" (click)="next()">&rarr;</a>

--- a/src/component/telemachy.component.ts
+++ b/src/component/telemachy.component.ts
@@ -94,4 +94,12 @@ export class TelemachyTourComponent implements OnInit, OnDestroy {
 			this.previous();
 		}
 	}
+	
+	public asHtmlTourStep(val: TourStep): HTMLTourStep {
+		return val as HTMLTourStep;
+	}
+
+	public asElementTourStep(val: TourStep): ElementTourStep {
+		return val as ElementTourStep;
+	}
 }

--- a/src/telemachy.ts
+++ b/src/telemachy.ts
@@ -22,4 +22,4 @@ import { YoutubeTourStep } from './step/youtube.step';
 })
 class TelemachyModule {}
 
-export { TelemachyModule, HasGuidedTour, TourPersistency, LocalstorageTourPersistency, LocalstorageTourPersistencyFactory, TourStep, ElementTourStep, HTMLTourStep, YoutubeTourStep, TelemachyService };
+export { TelemachyModule, HasGuidedTour, TourPersistency, LocalstorageTourPersistency, LocalstorageTourPersistencyFactory, TourStep, ElementTourStep, HTMLTourStep, YoutubeTourStep, TelemachyService, TelemachyTourComponent};


### PR DESCRIPTION
I exported the TourComponent in the Module file. Additionally, casting helper methods were added for the step object (prevent warnings in the template of an extended component).  I think it's ok, since the TourComponent already has a strong binding with the specialised classes.